### PR TITLE
feat: register 5 hidden MCP tools (#5)

### DIFF
--- a/scaffold/mcp-pm/src/index.ts
+++ b/scaffold/mcp-pm/src/index.ts
@@ -1515,6 +1515,96 @@ server.tool(
   },
 )
 
+// ══════════════════════════════════════════════════
+// SPRINT / STORY ASSIGNMENT TOOLS
+// ══════════════════════════════════════════════════
+
+// ── Tool: assign_story_to_sprint ──
+
+server.tool(
+  'assign_story_to_sprint',
+  'Assign a story to a sprint',
+  {
+    story_id: z.number().describe('Story ID'),
+    sprint_id: z.string().describe('Sprint ID'),
+  },
+  async ({ story_id, sprint_id }) => {
+    const { data, error } = await apiPatch<{ ok: boolean }>(`/api/v2/pm/stories/${story_id}`, { sprint: sprint_id })
+    if (error || !data) return err(error ?? 'Unknown error')
+    return text(`Story #${story_id} assigned to sprint ${sprint_id}`)
+  },
+)
+
+// ── Tool: unassign_story_from_sprint ──
+
+server.tool(
+  'unassign_story_from_sprint',
+  'Remove a story from its sprint (move to backlog)',
+  {
+    story_id: z.number().describe('Story ID'),
+  },
+  async ({ story_id }) => {
+    const { data, error } = await apiPatch<{ ok: boolean }>(`/api/v2/pm/stories/${story_id}`, { sprint: 'backlog' })
+    if (error || !data) return err(error ?? 'Unknown error')
+    return text(`Story #${story_id} moved to backlog`)
+  },
+)
+
+// ── Tool: checkin_sprint ──
+
+server.tool(
+  'checkin_sprint',
+  'Register team members for a sprint',
+  {
+    sprint_id: z.string().describe('Sprint ID'),
+    member_ids: z.array(z.number()).describe('Member IDs to register'),
+  },
+  async ({ sprint_id, member_ids }) => {
+    const { data, error } = await apiPost<{ ok: boolean; velocity?: number; teamSize?: number }>(
+      `/api/v2/kickoff/${sprint_id}/checkin`,
+      { memberIds: member_ids },
+    )
+    if (error || !data) return err(error ?? 'Unknown error')
+    return text(`Sprint ${sprint_id} check-in complete: ${member_ids.length} members registered`)
+  },
+)
+
+// ── Tool: add_absence ──
+
+server.tool(
+  'add_absence',
+  'Register absence dates for a sprint member',
+  {
+    sprint_id: z.string().describe('Sprint ID'),
+    member_id: z.number().describe('Member ID'),
+    dates: z.array(z.string()).describe('Absence dates (YYYY-MM-DD)'),
+    reason: z.string().optional().describe('Absence reason'),
+  },
+  async ({ sprint_id, member_id, dates, reason }) => {
+    const { data, error } = await apiPost<{ ok: boolean }>(
+      `/api/v2/kickoff/${sprint_id}/absence`,
+      { memberId: member_id, dates, reason },
+    )
+    if (error || !data) return err(error ?? 'Unknown error')
+    return text(`Absence registered for member #${member_id} in sprint ${sprint_id}: ${dates.length} day(s)`)
+  },
+)
+
+// ── Tool: reject_memo ──
+
+server.tool(
+  'reject_memo',
+  'Reject/reopen a resolved memo',
+  {
+    memo_id: z.number().describe('Memo ID to reject'),
+  },
+  async ({ memo_id }) => {
+    const { data, error } = await apiPatch<{ ok: boolean }>(`/api/v2/memos/${memo_id}/reopen`, {})
+    if (error || !data) return err(error ?? 'Unknown error')
+    return text(`Memo #${memo_id} rejected (reopened)`)
+  },
+)
+
 // ── Start ──
 
 async function main() {

--- a/scaffold/pm-api/src/mcp.ts
+++ b/scaffold/pm-api/src/mcp.ts
@@ -650,6 +650,68 @@ const TOOLS = [
       required: ['event_id'],
     },
   },
+
+  // ── Sprint / Story Assignment ──
+  {
+    name: 'assign_story_to_sprint',
+    description: 'Assign a story to a sprint',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        story_id: { type: 'number', description: 'Story ID' },
+        sprint_id: { type: 'string', description: 'Sprint ID' },
+      },
+      required: ['story_id', 'sprint_id'],
+    },
+  },
+  {
+    name: 'unassign_story_from_sprint',
+    description: 'Remove a story from its sprint (move to backlog)',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        story_id: { type: 'number', description: 'Story ID' },
+      },
+      required: ['story_id'],
+    },
+  },
+  {
+    name: 'checkin_sprint',
+    description: 'Register team members for a sprint',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        sprint_id: { type: 'string', description: 'Sprint ID' },
+        member_ids: { type: 'array', items: { type: 'number' }, description: 'Member IDs to register' },
+      },
+      required: ['sprint_id', 'member_ids'],
+    },
+  },
+  {
+    name: 'add_absence',
+    description: 'Register absence dates for a sprint member',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        sprint_id: { type: 'string', description: 'Sprint ID' },
+        member_id: { type: 'number', description: 'Member ID' },
+        dates: { type: 'array', items: { type: 'string' }, description: 'Absence dates (YYYY-MM-DD)' },
+        reason: { type: 'string', description: 'Absence reason' },
+      },
+      required: ['sprint_id', 'member_id', 'dates'],
+    },
+  },
+  {
+    name: 'reject_memo',
+    description: 'Reject/reopen a resolved memo',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        memo_id: { type: 'number', description: 'Memo ID to reject' },
+      },
+      required: ['memo_id'],
+    },
+  },
 ]
 
 // ── Tool Handlers ──


### PR DESCRIPTION
## Summary

Registers 5 tools that existed in the backend (pm-api mcp-tools) but were missing from:
1. The `TOOLS` array in `pm-api/src/mcp.ts` (tools/list response)
2. The MCP server in `mcp-pm/src/index.ts`

## Tools Added

| Tool | Description | API Endpoint |
|------|-------------|--------------|
| `assign_story_to_sprint` | Assign a story to a sprint | PATCH /api/v2/pm/stories/:id |
| `unassign_story_from_sprint` | Move story to backlog | PATCH /api/v2/pm/stories/:id (sprint=backlog) |
| `checkin_sprint` | Register team members for a sprint | POST /api/v2/kickoff/:id/checkin |
| `add_absence` | Register absence dates for a sprint member | POST /api/v2/kickoff/:id/absence |
| `reject_memo` | Reject/reopen a resolved memo | PATCH /api/v2/memos/:id/reopen |

## Verification

```
cd scaffold/mcp-pm && npm run build  ✅
```

Closes #5