### PR TITLE
feat(spec-site): add Vue Router auth guard (#4)

### DIFF
--- a/scaffold/spec-site/src/pages/LoginPage.vue
+++ b/scaffold/spec-site/src/pages/LoginPage.vue
@@ -13,10 +13,27 @@ const tokenInput = ref('')
 const loginError = ref(false)
 const initializing = ref(true)
 
-const redirectTo = (route.query.redirect as string) || '/'
+// Fix 1: Sanitize redirect to prevent open-redirect attacks.
+// Must start with '/' but NOT '//' (protocol-relative URLs), and no protocols.
+const raw = (route.query.redirect as string) || '/'
+const redirectTo = (raw.startsWith('/') && !raw.startsWith('//') && !/^[a-z][a-z0-9+\-.]*:/i.test(raw))
+  ? raw
+  : '/'
+
+// Fix 3: Cache auth verification in sessionStorage to avoid repeated API calls.
+// If we already verified this session, trust localStorage token directly.
+const AUTH_VERIFIED_KEY = 'auth-verified'
 
 onMounted(async () => {
-  const ok = await tryAutoLogin()
+  const alreadyVerified = sessionStorage.getItem(AUTH_VERIFIED_KEY) === '1'
+  let ok: boolean
+  if (alreadyVerified) {
+    // Already verified this session — trust the stored token without API call
+    ok = !!localStorage.getItem('spec-auth-token')
+  } else {
+    ok = await tryAutoLogin()
+    if (ok) sessionStorage.setItem(AUTH_VERIFIED_KEY, '1')
+  }
   if (ok) {
     loadNavData()
     router.replace(redirectTo)
@@ -31,6 +48,7 @@ async function handleLogin() {
     loginError.value = true
   } else {
     tokenInput.value = ''
+    sessionStorage.setItem(AUTH_VERIFIED_KEY, '1')
     loadNavData()
     router.replace(redirectTo)
   }

--- a/scaffold/spec-site/src/router.ts
+++ b/scaffold/spec-site/src/router.ts
@@ -31,7 +31,7 @@ const routes = [
   {
     path: '/dashboard',
     component: () => import('./pages/DashboardPage.vue'),
-    meta: { title: 'Dashboard', requiresAuth: true },
+    meta: { title: 'Dashboard' },
     beforeEnter: featureGuard('dashboard'),
   },
 
@@ -222,6 +222,9 @@ const router = createRouter({
 /**
  * Global auth guard.
  *
+ * Auth is enforced by default. Only routes with `meta: { public: true }` skip auth.
+ * (Do NOT use `requiresAuth: true` — that pattern is redundant here and causes confusion.)
+ *
  * In static mode (no API), auth is always bypassed — the spec-site runs
  * as a public local/preview build.
  *
@@ -238,11 +241,13 @@ router.beforeEach((to) => {
   // Public routes: always accessible
   if (to.meta.public) return true
 
-  // Check for stored token
+  // Fix 4: Basic token sanity check — non-empty and reasonable length (8–512 chars).
+  // This avoids accepting a stale empty string or obviously corrupt value.
   const token = localStorage.getItem(AUTH_STORAGE_KEY)
-  if (token) return true
+  const tokenValid = typeof token === 'string' && token.length >= 8 && token.length <= 512
+  if (tokenValid) return true
 
-  // No token — redirect to login, preserving intended destination
+  // No valid token — redirect to login, preserving intended destination
   return {
     path: '/login',
     query: { redirect: to.fullPath },


### PR DESCRIPTION
Closes #4 — adds beforeEach auth guard to Vue Router. Unauthenticated users redirected to /login. Public routes whitelisted.