### PR TITLE
feat(api): add GET /:id endpoints (#6)

### DIFF
--- a/scaffold/mcp-pm/src/index.ts
+++ b/scaffold/mcp-pm/src/index.ts
@@ -730,6 +730,21 @@ server.tool(
 // SPRINT TOOLS
 // ══════════════════════════════════════════════════
 
+// ── Tool: get_sprint ──
+
+server.tool(
+  'get_sprint',
+  'Get sprint by ID',
+  {
+    sprint_id: z.string().describe('Sprint ID (e.g. s55)'),
+  },
+  async ({ sprint_id }) => {
+    const { data, error } = await apiGet<Record<string, unknown>>(`/api/v2/nav/sprints/${sprint_id}`)
+    if (error || !data) return err(error ?? 'Unknown error')
+    return text(JSON.stringify(data, null, 2))
+  },
+)
+
 // ── Tool 19: list_sprints ──
 
 server.tool(
@@ -957,6 +972,21 @@ server.tool(
 // EPIC TOOLS
 // ══════════════════════════════════════════════════
 
+// ── Tool: get_epic ──
+
+server.tool(
+  'get_epic',
+  'Get epic by ID',
+  {
+    epic_id: z.number().describe('Epic ID'),
+  },
+  async ({ epic_id }) => {
+    const { data, error } = await apiGet<Record<string, unknown>>(`/api/v2/pm/epics/${epic_id}`)
+    if (error || !data) return err(error ?? 'Unknown error')
+    return text(JSON.stringify(data, null, 2))
+  },
+)
+
 // ── Tool 27: list_epics ──
 
 server.tool(
@@ -1040,6 +1070,21 @@ server.tool(
 // ══════════════════════════════════════════════════
 // STORY TOOLS
 // ══════════════════════════════════════════════════
+
+// ── Tool: get_story ──
+
+server.tool(
+  'get_story',
+  'Get story by ID',
+  {
+    story_id: z.number().describe('Story ID'),
+  },
+  async ({ story_id }) => {
+    const { data, error } = await apiGet<Record<string, unknown>>(`/api/v2/pm/stories/${story_id}`)
+    if (error || !data) return err(error ?? 'Unknown error')
+    return text(JSON.stringify(data, null, 2))
+  },
+)
 
 // ── Tool 31: list_stories ──
 
@@ -1184,6 +1229,21 @@ server.tool(
 // ══════════════════════════════════════════════════
 // TASK TOOLS (extended)
 // ══════════════════════════════════════════════════
+
+// ── Tool: get_task_raw ──
+
+server.tool(
+  'get_task_raw',
+  'Get task by ID (raw DB row)',
+  {
+    task_id: z.number().describe('Task ID'),
+  },
+  async ({ task_id }) => {
+    const { data, error } = await apiGet<Record<string, unknown>>(`/api/v2/pm/tasks/${task_id}`)
+    if (error || !data) return err(error ?? 'Unknown error')
+    return text(JSON.stringify(data, null, 2))
+  },
+)
 
 // ── Tool 36: update_task ──
 

--- a/scaffold/pm-api/src/mcp.ts
+++ b/scaffold/pm-api/src/mcp.ts
@@ -44,6 +44,15 @@ const TOOLS = [
     inputSchema: { type: 'object', properties: {} },
   },
   {
+    name: 'get_sprint',
+    description: 'Get sprint by ID',
+    inputSchema: {
+      type: 'object',
+      properties: { sprint_id: { type: 'string', description: 'Sprint ID (e.g. s55)' } },
+      required: ['sprint_id'],
+    },
+  },
+  {
     name: 'activate_sprint',
     description: 'Activate a sprint (deactivates others)',
     inputSchema: {
@@ -142,6 +151,15 @@ const TOOLS = [
     inputSchema: { type: 'object', properties: {} },
   },
   {
+    name: 'get_epic',
+    description: 'Get epic by ID',
+    inputSchema: {
+      type: 'object',
+      properties: { epic_id: { type: 'number', description: 'Epic ID' } },
+      required: ['epic_id'],
+    },
+  },
+  {
     name: 'add_epic',
     description: 'Create new epic',
     inputSchema: {
@@ -204,6 +222,15 @@ const TOOLS = [
         status: { type: 'string', enum: ['draft', 'backlog', 'ready', 'in-progress', 'review', 'done'], description: 'Status' },
         assignee: { type: 'string', description: 'Assignee filter' },
       },
+    },
+  },
+  {
+    name: 'get_story',
+    description: 'Get story by ID',
+    inputSchema: {
+      type: 'object',
+      properties: { story_id: { type: 'number', description: 'Story ID' } },
+      required: ['story_id'],
     },
   },
   {
@@ -739,6 +766,12 @@ async function handleTool(name: string, args: Record<string, unknown>, user: str
 
     // Epics
     case 'list_epics': return toolListEpics()
+    case 'get_epic': {
+      const id = args.epic_id as number
+      const result = await query<Record<string, unknown>>('SELECT * FROM pm_epics WHERE id = ?', [id])
+      if (!result.rows.length) return err('Epic not found')
+      return text(JSON.stringify(result.rows[0], null, 2))
+    }
     case 'add_epic': return toolAddEpic(user, args)
     case 'update_epic': return toolUpdateEpic(args)
     case 'delete_epic': return toolDeleteEpic(args)
@@ -746,6 +779,12 @@ async function handleTool(name: string, args: Record<string, unknown>, user: str
     // Stories
     case 'list_stories': return toolListStories(args)
     case 'list_backlog': return toolListBacklog(args)
+    case 'get_story': {
+      const id = args.story_id as number
+      const result = await query<Record<string, unknown>>('SELECT * FROM pm_stories WHERE id = ?', [id])
+      if (!result.rows.length) return err('Story not found')
+      return text(JSON.stringify(result.rows[0], null, 2))
+    }
     case 'add_story': return toolAddStory(user, args)
     case 'update_story': return toolUpdateStory(user, args)
     case 'delete_story': return toolDeleteStory(args)
@@ -753,6 +792,15 @@ async function handleTool(name: string, args: Record<string, unknown>, user: str
     // Tasks
     case 'list_my_tasks': return toolListTasks(user, args)
     case 'get_task': return toolGetTask(args)
+    case 'get_sprint': {
+      const id = args.sprint_id as string
+      const result = await query<Record<string, unknown>>(
+        'SELECT id, COALESCE(label, title) AS label, theme, status, active, start_date, end_date, velocity, team_size, sort_order, created_at, updated_at FROM nav_sprints WHERE id = ?',
+        [id],
+      )
+      if (!result.rows.length) return err('Sprint not found')
+      return text(JSON.stringify(result.rows[0], null, 2))
+    }
     case 'update_task_status': return toolUpdateTaskStatus(args)
     case 'update_task': return toolUpdateTask(user, args)
     case 'add_task': return toolAddTask(user, args)

--- a/scaffold/pm-api/src/routes/v2-nav.ts
+++ b/scaffold/pm-api/src/routes/v2-nav.ts
@@ -98,6 +98,17 @@ app.get('/sprints/timeline', async (c) => {
   return c.json({ timeline })
 })
 
+// GET /sprints/:id
+app.get('/sprints/:id', async (c) => {
+  const id = c.req.param('id')
+  const result = await query<Record<string, unknown>>(
+    'SELECT id, COALESCE(label, title) AS label, theme, status, active, start_date, end_date, velocity, team_size, sort_order, created_at, updated_at FROM nav_sprints WHERE id = ?',
+    [id],
+  )
+  if (!result.rows.length) return c.json({ error: 'Not found' }, 404)
+  return c.json(result.rows[0])
+})
+
 // PATCH /sprints/:id
 app.patch('/sprints/:id', async (c) => {
   const id = c.req.param('id')

--- a/scaffold/pm-api/src/routes/v2-pm.ts
+++ b/scaffold/pm-api/src/routes/v2-pm.ts
@@ -26,6 +26,14 @@ app.get('/epics', async (c) => {
   return c.json({ epics: rows })
 })
 
+// GET /epics/:id
+app.get('/epics/:id', async (c) => {
+  const id = c.req.param('id')
+  const result = await query<Record<string, unknown>>('SELECT * FROM pm_epics WHERE id = ?', [id])
+  if (!result.rows.length) return c.json({ error: 'Not found' }, 404)
+  return c.json(result.rows[0])
+})
+
 // GET /data
 app.get('/data', async (c) => {
   const sprint = c.req.query('sprint')
@@ -112,6 +120,14 @@ app.delete('/epics/:id', async (c) => {
   return c.json({ ok: true })
 })
 
+// GET /stories/:id
+app.get('/stories/:id', async (c) => {
+  const id = c.req.param('id')
+  const result = await query<Record<string, unknown>>('SELECT * FROM pm_stories WHERE id = ?', [id])
+  if (!result.rows.length) return c.json({ error: 'Not found' }, 404)
+  return c.json(result.rows[0])
+})
+
 // POST /stories
 app.post('/stories', async (c) => {
   const body = await c.req.json<{
@@ -190,6 +206,14 @@ app.delete('/stories/:id', async (c) => {
   const r2 = await execute('DELETE FROM pm_stories WHERE id = ?', [id])
   if (r2.error) return c.json({ error: r2.error }, 500)
   return c.json({ ok: true })
+})
+
+// GET /tasks/:id
+app.get('/tasks/:id', async (c) => {
+  const id = c.req.param('id')
+  const result = await query<Record<string, unknown>>('SELECT * FROM pm_tasks WHERE id = ?', [id])
+  if (!result.rows.length) return c.json({ error: 'Not found' }, 404)
+  return c.json(result.rows[0])
 })
 
 // POST /tasks


### PR DESCRIPTION
Closes #6 — adds single-resource GET endpoints for epics, stories, tasks, sprints + MCP tools.